### PR TITLE
src/modules/mavlink/mavlink_messages.cpp: fix statustext printing

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -403,7 +403,7 @@ protected:
 
 	bool send(const hrt_abstime t)
 	{
-		if (!_mavlink->get_logbuffer()->empty() && _mavlink->is_connected()) {
+		if (!_mavlink->get_logbuffer()->empty()) {
 
 			struct mavlink_log_s mavlink_log = {};
 


### PR DESCRIPTION
This fix makes possible to send statustext to MAVROS if it's connected through USB.